### PR TITLE
Update the elasticsearch plan name on cloud.gov

### DIFF
--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -33,7 +33,7 @@ if [ "$1" = "setup" ] ; then  echo
 	if service_exists "scanner-es" ; then
 	  echo scanner-es already created
 	else
-	  cf create-service elasticsearch56 medium scanner-es
+	  cf create-service elasticsearch56 medium-ha scanner-es
 	  echo sleeping until ES is awake
 	  for i in a b c ; do
 	  	sleep 60


### PR DESCRIPTION
Cloud.gov recently changed their pricing and offerings. https://cloud.gov/updates/2019-08-26-changes-to-cloud-gov-services-and-prices/

One of the changes was to change the available elasticsearch plan names. This PR reflects that change. I just had a similar PR merged on the cloud.gov repo itself to update one of their examples. https://github.com/18F/cg-site/commit/907172a040dad5f9dbd03abbfa0c9e401254c99f