### PR TITLE
Make the scan data urls pretty

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ applications:
   services:
     - scanner-storage
     - scanner-es
-  memory: 128M
+  memory: 1024M
   instances: 1
   random-route: true
   command: python3 manage.py collectstatic --noinput ; gunicorn -b :8080 scanner_ui.wsgi

--- a/scanner_ui/api/serializers.py
+++ b/scanner_ui/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-class DomainsSerializer(serializers.Serializer):
+class ScanSerializer(serializers.Serializer):
 	domain = serializers.CharField(max_length=200)
 	scantype = serializers.CharField(max_length=200)
 	domaintype = serializers.CharField(max_length=200, required=False)

--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -5,33 +5,13 @@ from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient
 from rest_framework.views import status
 from .serializers import DomainsSerializer
-from .views import getDomain
-from .views import getScantype
+from .views import getScans
 from django.conf import settings
 import boto3
 import os
 
 
 # tests for views
-
-class GetAllDomainsTest(APITestCase):
-    client = APIClient()
-
-    def test_get_all_domains(self):
-        """
-        This test ensures that all domains
-        exist when we make a GET request to the domains/ endpoint.
-        """
-        # hit the API endpoint
-        response = self.client.get(
-            reverse("domains-list")
-        )
-        # fetch the data
-        expected = getDomain()
-
-        serialized = DomainsSerializer(expected, many=True)
-        self.assertEqual(response.data, serialized.data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 class GetAllScansTest(APITestCase):
     client = APIClient()
@@ -46,7 +26,7 @@ class GetAllScansTest(APITestCase):
             reverse("scans-list")
         )
         # fetch the data
-        expected = getScantype()
+        expected = getScans()
 
         serialized = DomainsSerializer(expected, many=True)
         self.assertEqual(response.data, serialized.data)

--- a/scanner_ui/api/tests.py
+++ b/scanner_ui/api/tests.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APITestCase, APIClient
 from rest_framework.views import status
-from .serializers import DomainsSerializer
-from .views import getScans
+from .serializers import ScanSerializer
+from .views import getScansFromES
 from django.conf import settings
 import boto3
 import os
@@ -26,8 +26,8 @@ class GetAllScansTest(APITestCase):
             reverse("scans-list")
         )
         # fetch the data
-        expected = getScans()
+        expected = getScansFromES()
 
-        serialized = DomainsSerializer(expected, many=True)
+        serialized = ScanSerializer(expected, many=True)
         self.assertEqual(response.data, serialized.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/scanner_ui/api/urls.py
+++ b/scanner_ui/api/urls.py
@@ -14,10 +14,15 @@ scans_list = ScansViewset.as_view({
 scans_detail = ScansViewset.as_view({
     'get': 'retrieve'
 })
+scan = ScansViewset.as_view({
+    'get': 'scan'
+})
 
 urlpatterns = [
     path('domains/', domains_list, name="domains-list"),
-    path('domains/<pk>/', domains_detail, name="domains-detail"),
+    path('domains/<domain>/', domains_detail, name="domains-detail"),
+    path('domains/<domain>/<scantype>/', scan, name="scan"),
     path('scans/', scans_list, name="scans-list"),
-    path('scans/<pk>/', scans_detail, name="scans-detail")
+    path('scans/<scantype>/', scans_detail, name="scans-detail"),
+    path('scans/<scantype>/<domain>/', scan, name="scan"),
 ]

--- a/scanner_ui/api/views.py
+++ b/scanner_ui/api/views.py
@@ -4,96 +4,90 @@ import boto3
 from rest_framework import generics
 from rest_framework import viewsets
 from rest_framework.response import Response
-from .serializers import DomainsSerializer
+from .serializers import ScanSerializer
 import os
 import json
 import re
 from collections import defaultdict
+from scanner_ui.ui.views import getdates
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Search
 
 # Create your views here.
 
-def getMetadatafromS3():
-	s3_resource = boto3.resource('s3')
-	return s3_resource.Bucket(os.environ['BUCKETNAME']).objects.all()
 
-def getScanFromS3(path):
-	s3_resource = boto3.resource('s3')
-	response = s3_resource.Object(os.environ['BUCKETNAME'],path).get()
-	return {'body': response['Body'].read(), 'lastmodified': response['LastModified']}
-
-
-# This function provides a reference to the domain scan data in it's s3 bucket
-# If scantype is None, then we want all the scans.
-def getScantype(scantype=None):
-	scans = []
-	for f in getMetadatafromS3():
-		if not re.search('\.json$', f.key):
-			continue
-		s3scantype = os.path.dirname(f.key)
-		if scantype == None or s3scantype == scantype:
-			scandomain = os.path.basename(os.path.splitext(f.key)[0])
-			scan_data_url = "https://s3-" + os.environ['AWS_DEFAULT_REGION'] + ".amazonaws.com/" + os.environ['BUCKETNAME'] + "/" + f.key
-			scans.append({"domain": scandomain, "scantype": s3scantype, "lastmodified": f.last_modified, "scan_data_url": scan_data_url})
-	return scans
-
-# get all the scans of the type and domain specified.  If the type is
+# get all the scans of the type and domain specified from ES.  If the type is
 # None, you get all of that scantype.  If the domain is None, you
-# get all domains.
-def getScans(scantype=None, domain=None):
+# get all domains.  If you supply a request, set the API url up
+# for the scan using it.
+def getScansFromES(scantype=None, domain=None, request=None):
+	es = Elasticsearch([os.environ['ESURI']])
+	dates = getdates()
+	latestindex = dates[1] + '-*'
+	indices = list(es.indices.get_alias(latestindex).keys())
+	y, m, d, scantypes = zip(*(s.split("-") for s in indices))
+
+	if scantype in scantypes:
+		index = dates[1] + '-' + scantype
+		s = Search(using=es, index=index)
+	else:
+		s = Search(using=es, index=latestindex)
+
+	s = s.sort('domain')
+
+	if domain != None:
+		s = s.filter("term", domain=domain)
+
+	if request != None:
+		apiurl = request.scheme + '://' + request.get_host() + '/api/v1/scans/'
+
 	scans = []
-	for f in getMetadatafromS3():
-		if not re.search('\.json$', f.key):
-			continue
-		s3scantype = os.path.dirname(f.key)
-		scandomain = os.path.basename(os.path.splitext(f.key)[0])
-		if scantype == None or s3scantype == scantype:
-			if domain == None or scandomain == domain:
-				scandata = getScanFromS3(f.key)
-				json_data = json.loads(scandata['body'])
-				scans.append(json_data)
+	for i in s.scan():
+		if request != None:
+			i['scan_data_url'] = apiurl + i['scantype'] + '/' + i['domain'] + '/'
+		scans.append(i.to_dict())
+
 	return scans
 
-
-# This function provides a reference to the scan data in it's s3 bucket
-# If domain is None, then we want all the domains.
-def getDomain(domain=None):
-	scans = []
-	for f in getMetadatafromS3():
-		if not re.search('\.json$', f.key):
-			continue
-		scandomain = os.path.basename(os.path.splitext(f.key)[0])
-		if domain == None or scandomain == domain:
-			scantype = os.path.dirname(f.key)
-			scan_data_url = "https://s3-" + os.environ['AWS_DEFAULT_REGION'] + ".amazonaws.com/" + os.environ['BUCKETNAME'] + "/" + f.key
-			scans.append({"domain": scandomain, "scantype": scantype, "lastmodified": f.last_modified, "scan_data_url": scan_data_url})
-	return scans
+# class ElasticsearchPagination(pagination.PageNumberPagination):
+# 	def paginate_queryset(self, queryset, request, view=None):
+# 		page_size = self.get_page_size(request)
+# 		if not page_size:
+# 			return None
+# 		page_number = request.query_params.get(self.page_query_param, 1)
+# 		if not page_number:
+#         	return None
+# 		start = page_size * (page_number - 1)
+# 		finish = start + page_size
+# 		return queryset[start:finish]
 
 
 class DomainsViewset(viewsets.ViewSet):
 	def list(self, request):
-		domains = getDomain()
-		serializer = DomainsSerializer(domains, many=True)
+		scans = getScansFromES(request=request)
+		serializer = ScanSerializer(scans, many=True)
 		return Response(serializer.data)
 
 	def retrieve(self, request, domain=None):
-		domains = getScans(domain=pk)
-		serializer = DomainsSerializer(domains, many=True)
+		scans = getScansFromES(domain=domain, request=request)
+		serializer = ScanSerializer(scans, many=True)
 		return Response(serializer.data)
 
 class ScansViewset(viewsets.ViewSet):
 	def list(self, request):
-		domains = getScantype()
-		serializer = DomainsSerializer(domains, many=True)
+		scans = getScansFromES(request=request)
+		serializer = ScanSerializer(scans, many=True)
 		return Response(serializer.data)
 
 	def retrieve(self, request, scantype=None):
-		domains = getScantype(pk)
-		serializer = DomainsSerializer(domains, many=True)
+		scans = getScansFromES(scantype=scantype, request=request)
+		serializer = ScanSerializer(scans, many=True)
 		return Response(serializer.data)
 
 	def scan(self, request, scantype=None, domain=None):
-		scan = getScans(scantype=scantype, domain=domain)
+		scan = getScansFromES(scantype=scantype, domain=domain, request=request)
+		print('request is', request)
 		if len(scan) != 1:
 			raise Exception('too many or too few scans', scan)
-		serializer = DomainsSerializer(scan[0])
+		serializer = ScanSerializer(scan[0])
 		return Response(serializer.data)

--- a/scanner_ui/settings.py
+++ b/scanner_ui/settings.py
@@ -145,7 +145,9 @@ STATICFILES_DIRS = [
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
-    )
+    ),
+    # 'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    # 'PAGE_SIZE': 100
 }
 
 # AWS info

--- a/scanner_ui/ui/views.py
+++ b/scanner_ui/ui/views.py
@@ -15,8 +15,10 @@ from elasticsearch_dsl.query import Range, Bool, Q
 
 es = Elasticsearch([os.environ['ESURI']])
 
+
+# search in ES for the list of dates that are indexed
 def getdates():
-	# search in ES for dates we can search in
+	es = Elasticsearch([os.environ['ESURI']])
 	indexlist = es.indices.get_alias().keys()
 	datemap = {}
 	for i in indexlist:
@@ -532,6 +534,7 @@ def searchUSWDScsv(request):
 
 # search in ES for the unique values in a particular field
 def getListFromFields(index, field):
+	es = Elasticsearch([os.environ['ESURI']])
 	s = Search(using=es, index=index).query().source([field])
 	valuemap = {}
 	try:


### PR DESCRIPTION
This is for https://github.com/18F/site-scanning/issues/102

It also switches the API from looking at S3 and instead using ES, which makes it lots faster.

The API now also gives out the full scan results instead of just giving pointers.  I may change this later because it uses up a fair amount of memory and may not scale.