### PR TITLE
enable zero downtime deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
             echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
             sudo apt-get update
             sudo apt-get install cf-cli
+            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            cf install-plugin blue-green-deploy -r CF-Community -f
       - run:
           name: deploy to cloud.gov
           command: |
@@ -59,7 +61,7 @@ jobs:
             cf api https://api.fr.cloud.gov
             cf auth "$CF_USERNAME" "$CF_PASSWORD"
             cf target -o "$CF_ORG" -s "$CF_SPACE"
-            ./deploy-cloudgov.sh
+            ./deploy-cloudgov.sh zdt
 
   scan:
     docker:

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -46,8 +46,7 @@ fi
 if [ "$1" = "zdt" ] ; then
 	# Do a zero downtime deploy.  This requires enough memory for
 	# two scanner-ui apps to exist in the org/space at one time.
-	# XXX right now, this seems to fail.  Not sure why.
-	cf v3-zdt-push scanner-ui || exit 1
+	cf blue-green-deploy scanner-ui || exit 1
 else
 	cf push || exit 1
 fi

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -46,7 +46,7 @@ fi
 if [ "$1" = "zdt" ] ; then
 	# Do a zero downtime deploy.  This requires enough memory for
 	# two scanner-ui apps to exist in the org/space at one time.
-	cf blue-green-deploy scanner-ui || exit 1
+	cf blue-green-deploy scanner-ui -f manifest.yml --delete-old-apps || exit 1
 else
 	cf push || exit 1
 fi

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,6 @@
 ---
 applications:
 - name: scanner-ui
-  buildpacks:
-    - python_buildpack
   disk_quota: 768M
   timeout: 180
   services:

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.3
+python-3.7.4


### PR DESCRIPTION
I tried to use the experimental v3-zdt-push feature, but it is broken somehow.  v3-zdt-restart works, but v3-zdt-push does not.
