### PR TITLE
Downscale domain scan batch size

### DIFF
--- a/getdomains.sh
+++ b/getdomains.sh
@@ -5,7 +5,9 @@
 #
 
 # This is how many domains to scan in a single task
-BATCHSIZE="${BATCHSIZE:-4500}"
+# 160 is chosen to produce 8 concurrent jobs over the current-federal.csv list,
+# which include 1242 domains.
+BATCHSIZE="${BATCHSIZE:-160}"
 
 BINDIR=$(dirname "$0")
 


### PR DESCRIPTION
Downscale concurrent domain scans from 4500 to 160, due to excessive crawl time on Lighthouse.