### PR TITLE
Fix Lighthouse and pshtt CSV exports

### DIFF
--- a/composetest.sh
+++ b/composetest.sh
@@ -34,7 +34,6 @@ calendar.gsa.gov,,,,,,
 EOF
 ./scan_engine.sh
 
-
 # run app test suite
 ./manage.py test || cleanup "python test suite exited uncleanly"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -74,6 +74,28 @@ domains can be [found here](composetest.sh)).
 
 **6. Run the app.**
 
+- The simplest way to run the app locally with a populated test database is to
+connect to the cloud.gov-deployed Elasticsearch database via an ssh tunnel:
+
+```bash
+cf7 connect-to-service scanner-ui scanner-es
+```
+
+If you have trouble making an ssh connection, you may need to use `cf7` and
+manually configure the port forwarding. Get the hostname and ports from the
+`connect-to-service` output, and run, replacing ports and hostname:
+
+```bash
+cf7 ssh -N -L 52046:hostname:32274 scanner-ui
+```
+
+- Set the `ESURL` environment variable to the provided port on localhost.
+
+- Run `./manage.py runserver` to start the Django development server
+
+Alternately, you may try to piggyback on the test runner's Docker-managed
+database:
+
 - Run `./test.sh nodelete` in the repo dir.  This will run the app, populate
 it with data scanned from a few domains, run the test suite against it,
 and leave the app running.

--- a/scanner_ui/api/urls.py
+++ b/scanner_ui/api/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
 
     path('scans/', scans_list, name="scans-list"),
     path('scans/<scantype>/', scans_detail, name="scans-detail"),
-    path('scans/<scantype>/csv/', views.retrievecsv, name="scans-csv"),
+    path('scans/<scantype>/csv/', views.retrieve_csv, name="scans-csv"),
     path('scans/<scantype>/<domain>/', scan, name="scan"),
 
     path('lists/<scantype>/agencies/', agencies, name="agencies"),
@@ -54,7 +54,7 @@ urlpatterns = [
 
     path('date/<date>/scans/', scans_list, name="date-scans-list"),
     path('date/<date>/scans/<scantype>/', scans_detail, name="date-scans-detail"),
-    path('date/<date>/scans/<scantype>/csv/', views.retrievecsv, name="date-scans-csv"),
+    path('date/<date>/scans/<scantype>/csv/', views.retrieve_csv, name="date-scans-csv"),
     path('date/<date>/scans/<scantype>/<domain>/', scan, name="date-scan"),
 
     path('date/<date>/lists/<scantype>/agencies/', agencies, name="date-agencies"),

--- a/scanner_ui/ui/tests.py
+++ b/scanner_ui/ui/tests.py
@@ -3,45 +3,45 @@ from django.test import Client
 import csv
 import re
 import json
-from .viewfunctions import getdates, getquery, getListFromFields, deperiodize, periodize, deslash, domainsWith, mixpagedatain, popupbuilder
+from .viewfunctions import get_dates, getquery, get_list_from_fields, deperiodize, periodize, deslash, domainsWith, mixpagedatain, popupbuilder
 
 # Create your tests here.
 
 
 class checkviewfunctions(SimpleTestCase):
-    def test_getdates(self):
-        dates = getdates()
+    def test_get_dates(self):
+        dates = get_dates()
         self.assertEqual(len(dates), 2)
         self.assertRegex(dates[1], r'^[0-9]{4}-[0-9]{2}-[0-9]{2}')
 
     def test_checkgetquery(self):
-        dates = getdates()
+        dates = get_dates()
         index = dates[1] + '-200scanner'
         s = getquery(index)
         self.assertEqual(s.count(), 7)
 
     def test_getquerydomainsearch(self):
-        dates = getdates()
+        dates = get_dates()
         index = dates[1] + '-200scanner'
         s = getquery(index, domainsearch='18f')
         self.assertEqual(s.count(), 1)
 
     def test_getquerydapsearch(self):
-        dates = getdates()
+        dates = get_dates()
         index = dates[1] + '-dap'
         s = getquery(index, present='DAP Present', displaytype='dap')
         self.assertEqual(s.count(), 4)
 
-    def test_getlistfromfields(self):
-        dates = getdates()
+    def test_get_list_from_fields(self):
+        dates = get_dates()
         index = dates[1] + '-200scanner'
-        mylist = getListFromFields(index, 'domain')
+        mylist = get_list_from_fields(index, 'domain')
         self.assertEqual(len(mylist), 7)
 
-    def test_getlistfromfields_subfield(self):
-        dates = getdates()
+    def test_get_list_from_fields_subfield(self):
+        dates = get_dates()
         index = dates[1] + '-pagedata'
-        mylist = getListFromFields(index, 'data', subfield='content_type')
+        mylist = get_list_from_fields(index, 'data', subfield='content_type')
         self.assertTrue('application/json' in mylist)
         self.assertTrue('application/xml' in mylist)
         self.assertGreaterEqual(len(mylist), 4)
@@ -59,13 +59,13 @@ class checkviewfunctions(SimpleTestCase):
         self.assertEqual(deslash(mystring), '\/data.json')
 
     def test_domainswith(self):
-        dates = getdates()
+        dates = get_dates()
         index = dates[1] + '-pagedata'
         domains = domainsWith('/privacy', 'responsecode', '200', index)
         self.assertEqual(len(domains), 2)
 
     def test_mixpagedatain(self):
-        dates = getdates()
+        dates = get_dates()
         indexbase = dates[1]
         index = indexbase + '-200scanner'
         s = getquery(index)

--- a/scanner_ui/ui/viewfunctions.py
+++ b/scanner_ui/ui/viewfunctions.py
@@ -95,7 +95,7 @@ def getquery(index, present=None, agency=None, domaintype=None, query=None, org=
 
 
 # search in ES for the list of dates that are indexed
-def getdates():
+def get_dates():
     es = Elasticsearch([os.environ['ESURL']])
     indexlist = es.indices.get_alias().keys()
     datemap = {}
@@ -120,7 +120,7 @@ def getdates():
 # like find all mime_types under all the different pages.
 #
 # XXX seems like there ought to be a way to do this with aggregates in ES.
-def getListFromFields(index, field, subfield=None):
+def get_list_from_fields(index, field, subfield=None):
     es = Elasticsearch([os.environ['ESURL']])
     s = Search(using=es, index=index).query().source([field])
     fieldlist = field.split('.')

--- a/scanner_ui/ui/views.py
+++ b/scanner_ui/ui/views.py
@@ -8,7 +8,7 @@ import csv
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from django.urls import reverse
-from .viewfunctions import getdates, getquery, periodize, mixpagedatain, getListFromFields, deperiodize, popupbuilder, setdisplaytypetitle
+from .viewfunctions import get_dates, getquery, periodize, mixpagedatain, get_list_from_fields, deperiodize, popupbuilder, setdisplaytypetitle
 
 
 # Create your views here.
@@ -62,7 +62,7 @@ def presentationlayers(request):
 
 
 def index(request):
-    dates = getdates()
+    dates = get_dates()
     latestindex = dates[1] + '-200scanner'
     es = Elasticsearch([os.environ['ESURL']])
 
@@ -89,7 +89,7 @@ def search200json(request):
     if my200page is None:
         my200page = 'All Scans'
 
-    dates = getdates()
+    dates = get_dates()
     indexbase = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         indexbase = dates[1]
@@ -163,7 +163,7 @@ def search200csv(request):
     if my200page is None:
         my200page = 'All Scans'
 
-    dates = getdates()
+    dates = get_dates()
     indexbase = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         indexbase = dates[1]
@@ -267,7 +267,7 @@ def search200(request, displaytype=None):
     hitsperpage = request.GET.get('hitsperpage')
     page_no = request.GET.get('page')
 
-    dates = getdates()
+    dates = get_dates()
     if date == 'None' or date == 'Scan Date' or date is None:
         indexbase = dates[1]
     else:
@@ -293,11 +293,11 @@ def search200(request, displaytype=None):
     my200pages.insert(0, 'All Scans')
 
     # get the agencies/domaintypes/orgs
-    agencies = getListFromFields(index, 'agency')
+    agencies = get_list_from_fields(index, 'agency')
     agencies.insert(0, 'All Agencies')
-    domaintypes = getListFromFields(index, 'domaintype')
+    domaintypes = get_list_from_fields(index, 'domaintype')
     domaintypes.insert(0, 'All Branches')
-    orgs = getListFromFields(index, 'organization')
+    orgs = get_list_from_fields(index, 'organization')
     orgs.insert(0, 'All Organizations')
 
     if agency is None:
@@ -310,7 +310,7 @@ def search200(request, displaytype=None):
         org = 'All Organizations'
 
     # Find list of mime types from the pagedata index
-    mimetypes = getListFromFields(indexbase + '-pagedata', 'data', subfield='content_type')
+    mimetypes = get_list_from_fields(indexbase + '-pagedata', 'data', subfield='content_type')
     mimetypes.insert(0, 'all content_types')
     if mimetype is None:
         mimetype = 'all content_types'
@@ -669,7 +669,7 @@ def searchUSWDSjson(request):
     domaintype = request.GET.get('domaintype')
     sort = request.GET.get('sort')
 
-    dates = getdates()
+    dates = get_dates()
     indexbase = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         indexbase = dates[1]
@@ -706,7 +706,7 @@ def searchUSWDScsv(request):
     domaintype = request.GET.get('domaintype')
     sort = request.GET.get('sort')
 
-    dates = getdates()
+    dates = get_dates()
     indexbase = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         indexbase = dates[1]
@@ -754,7 +754,7 @@ def searchUSWDScsv(request):
 
 
 def searchUSWDS(request):
-    dates = getdates()
+    dates = get_dates()
 
     date = request.GET.get('date')
     if date == 'None' or date == 'Scan Date' or date is None:
@@ -764,9 +764,9 @@ def searchUSWDS(request):
     index = indexbase + '-uswds2'
 
     # get the agencies/domaintypes
-    agencies = getListFromFields(index, 'agency')
+    agencies = get_list_from_fields(index, 'agency')
     agencies.insert(0, 'All Agencies')
-    domaintypes = getListFromFields(index, 'domaintype')
+    domaintypes = get_list_from_fields(index, 'domaintype')
     domaintypes.insert(0, 'All Branches')
 
     agency = request.GET.get('agency')
@@ -794,7 +794,7 @@ def searchUSWDS(request):
         versions.sort()
     except:
         versions = []
-    # versions = getListFromFields(index, 'data.uswdsversion')
+    # versions = get_list_from_fields(index, 'data.uswdsversion')
     versions.insert(0, 'detected versions')
     versions.insert(0, 'all versions')
 
@@ -855,7 +855,7 @@ def searchUSWDS(request):
 
 
 def privacy(request):
-    dates = getdates()
+    dates = get_dates()
 
     date = request.GET.get('date')
     if date == 'None' or date == 'Scan Date' or date is None:
@@ -865,9 +865,9 @@ def privacy(request):
     index = indexbase + '-privacy'
 
     # get the agencies/domaintypes
-    agencies = getListFromFields(index, 'agency')
+    agencies = get_list_from_fields(index, 'agency')
     agencies.insert(0, 'All Agencies')
-    domaintypes = getListFromFields(index, 'domaintype')
+    domaintypes = get_list_from_fields(index, 'domaintype')
     domaintypes.insert(0, 'All Branches')
 
     agency = request.GET.get('agency')
@@ -963,7 +963,7 @@ def privacyjson(request):
     domaintype = request.GET.get('domaintype')
     present = request.GET.get('present')
 
-    dates = getdates()
+    dates = get_dates()
     index = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         index = dates[1] + '-privacy'
@@ -993,7 +993,7 @@ def privacycsv(request):
     domaintype = request.GET.get('domaintype')
     present = request.GET.get('present')
 
-    dates = getdates()
+    dates = get_dates()
     index = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         index = dates[1] + '-privacy'
@@ -1031,7 +1031,7 @@ def privacycsv(request):
 
 
 def sitemap(request):
-    dates = getdates()
+    dates = get_dates()
 
     date = request.GET.get('date')
     if date == 'None' or date == 'Scan Date' or date is None:
@@ -1041,9 +1041,9 @@ def sitemap(request):
     index = indexbase + '-sitemap'
 
     # get the agencies/domaintypes
-    agencies = getListFromFields(index, 'agency')
+    agencies = get_list_from_fields(index, 'agency')
     agencies.insert(0, 'All Agencies')
-    domaintypes = getListFromFields(index, 'domaintype')
+    domaintypes = get_list_from_fields(index, 'domaintype')
     domaintypes.insert(0, 'All Branches')
 
     agency = request.GET.get('agency')
@@ -1137,7 +1137,7 @@ def sitemapjson(request):
     domaintype = request.GET.get('domaintype')
     present = request.GET.get('present')
 
-    dates = getdates()
+    dates = get_dates()
     index = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         index = dates[1] + '-sitemap'
@@ -1167,7 +1167,7 @@ def sitemapcsv(request):
     domaintype = request.GET.get('domaintype')
     present = request.GET.get('present')
 
-    dates = getdates()
+    dates = get_dates()
     index = ''
     if date == 'None' or date == 'Scan Date' or date is None:
         index = dates[1] + '-sitemap'

--- a/test.sh
+++ b/test.sh
@@ -36,7 +36,7 @@ SAVEDEXIT=$?
 #   -config spider.postform=true"
 # CONTAINER=$(docker-compose images | awk '/zaproxy/ {print $1}')
 # echo "====================================== OWASP ZAP tests"
-# docker exec "$CONTAINER" zap-full-scan.py -t http://scanner-ui:8000/about/ -m 5 -z "${ZAP_CONFIG}" | tee /tmp/zap.out 
+# docker exec "$CONTAINER" zap-full-scan.py -t http://scanner-ui:8000/about/ -m 5 -z "${ZAP_CONFIG}" | tee /tmp/zap.out
 # if grep 'FAIL-NEW: 0' /tmp/zap.out >/dev/null ; then
 # 	echo 'passed OWASP ZAP'
 # else


### PR DESCRIPTION
In order to fix CSV exports for Lighthouse and pshtt, only flatten their scan dictionaries to the known depth where each has consistently named keys.

Implements #495 