### PR TITLE
Update Spotlight to site-scanning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The Site Scanning program highlights the features contributing to any federal we
 
 You are viewing the scanner's back-end code. Check out the [program documentation](https://github.com/18F/site-scanning-documentation) for front-end code.
 
-To install Spotlight locally:
+To install `site-scanning` locally:
 * [How to get started](docs/INSTALL.md)
 * [How to manage deployment in cloud.gov](docs/DevOps.md)
 
-To customize Spotlight API:
+To customize `site-scanning` API:
 * [Basic architecture](docs/Architecture.md)
 * [Example code using API](tools/)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
-# Setup Spotlight
+# Setup site-scanning
 
-Spotlight is engineered to run on cloud.gov using CircleCI for CI/CD.
+site-scanning is engineered to run on cloud.gov using CircleCI for CI/CD.
 You can also run a local copy for local development. 
 You should run these commands on a Mac OS X or Linux host which has tools such as cf, jq, curl, bash, etc on them.
 
@@ -13,9 +13,9 @@ or by getting an IAA signed and then getting a real production cloud.gov org.
 - Once you are set up and able to issue cloudfoundry commands like `cf target`, you will be able to proceed.
 
 ### Complete the initial setup
-- Clone the repo with `git clone https://github.com/18F/Spotlight` or `git clone git@github.com:18F/Spotlight.git` over SSH.
+- Clone the repo with `git clone https://github.com/18F/site-scanning` or `git clone git@github.com:18F/site-scanning.git` over SSH.
 
-- `cd Spotlight` to get into the repo dir.
+- `cd site-scanning` to get into the repo dir.
 - Create the services required and do the initial app push:
 	- If you are in a sandbox org/space, do this: `./deploy-cloudgov.sh setup`.
 	- If you are in a production org/space, do this: `./deploy-cloudgov.sh setup prod`
@@ -49,11 +49,11 @@ automatically.
 
 ## Development Setup
 
-Spotlight requires Docker and Python to run locally.
+`site-scanning` requires Docker and Python to run locally.
 
 ### Code
-- Clone the repo with `git clone https://github.com/18F/Spotlight` or `git clone git@github.com:18F/Spotlight.git` over SSH.
-- `cd Spotlight` to get into the repo dir.
+- Clone the repo with `git clone https://github.com/18F/site-scanning` or `git clone git@github.com:18F/site-scanning.git` over SSH.
+- `cd site-scanning to get into the repo dir.
 
 ### Docker
 - [Install Docker](https://docs.docker.com/install/).
@@ -133,7 +133,7 @@ branch, and it will do a test then deploy.
 setup, but this is unfinished as of now.
 
 ### Domain Scan
-- Spotlight uses the [domain-scan](https://github.com/18F/domain-scan) engine
+- `site-scanning` uses the [domain-scan](https://github.com/18F/domain-scan) engine
 to do the work of parallelizing and collecting all of the scan data. Documention exists to help you [add new scanners](https://github.com/18F/domain-scan#developing-new-scanners).
 
 #### Set up local development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 authors = ["Alex Hendrie Bielen <alex.bielen@gsa.gov>"]
-description = "Spotlight highlights the features contributing to any federal website's success, for free."
-name = "spotlight"
+description = "site-scanning highlights the features contributing to any federal website's success, for free."
+name = "site-scanning"
 version = "0.1.0"
 
 [tool.poetry.dependencies]

--- a/scanner_ui/api/urls.py
+++ b/scanner_ui/api/urls.py
@@ -13,7 +13,7 @@ agencies = ListsViewset.as_view({"get": "agencies"})
 domaintypes = ListsViewset.as_view({"get": "domaintypes"})
 fieldvalues = ListsViewset.as_view({"get": "fieldvalues"})
 dates = ListsViewset.as_view({"get": "dates"})
-swagger_view = get_swagger_view(title="Spotlight API")
+swagger_view = get_swagger_view(title="site-scanning API")
 
 urlpatterns = [
     path("", swagger_view, name="docs"),

--- a/utilities/get_scan_counts.py
+++ b/utilities/get_scan_counts.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import requests
 
 
-API_ROOT = "https://spotlight.app.cloud.gov/api/v1"
+API_ROOT = "https://site-scanning.app.cloud.gov/api/v1"
 SCAN_TYPES = [
     "200scanner",
     "dap",


### PR DESCRIPTION
Why: We are cleaning up the distinction between Spotlight (a view of the
data) and site-scanning (the API and related site-scanner).

How: s/Spotlight/site-scanning/ (pretty much).

Tags: renaming