### PR TITLE
Update docs to new API URL

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,1 +1,1 @@
-These have been moved to https://open.gsa.gov/api/spotlight-api/
+These have been moved to https://open.gsa.gov/api/site-scanning-api/


### PR DESCRIPTION
Closes #619.

Why: Get rid of the Spotlight name throughout the application.

How: Updating the documentation.

Tags: docs